### PR TITLE
WRI-10: Update postgresql jdbc version, without vulnerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 		<java.version>17</java.version>
 		<spring.boot.version>3.0.0-SNAPSHOT</spring.boot.version>
 		<h2.version>2.1.214</h2.version>
-		<postgreesql.version>42.3.6</postgreesql.version>
+		<postgreesql.version>42.4.1</postgreesql.version>
 		<lombok.version>1.18.24</lombok.version>
 	</properties>
 


### PR DESCRIPTION
In version 42.3.6, security vulnerabilities were found.